### PR TITLE
fix: メッセージのテスト時のコメントを修正

### DIFF
--- a/test/features/create-message.test.ts
+++ b/test/features/create-message.test.ts
@@ -25,7 +25,7 @@ export async function createMessage() {
   assert.equal(
     response.status,
     422,
-    'roomに入ってないユーザーのメッセージを作ろうとしているので、400になるべき'
+    'roomに入ってないユーザーのメッセージを作ろうとしているので、422になるべき'
   )
 }
 


### PR DESCRIPTION
## 概要
メッセージ周りのテスト時に、`status code`が`422`になることを想定していたが、メッセージが`400になるべき`となっていたので、`422になるべき`に修正